### PR TITLE
Make better use of Alien::TinyCC; move towards Windows compilation

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -58,19 +58,18 @@ WriteMakefile1(
     LICENSE => 'perl',
     ABSTRACT_FROM => 'lib/XS/TCC.pm',
     AUTHOR => 'Steffen Mueller <smueller@cpan.org>',
-    #LIBS              => ['-L' . , '-ltcc'], # e.g., '-lm'
+    Alien::TinyCC->EUMM_LIBS,
+    Alien::TinyCC->EUMM_OBJECT,
     DEFINE            => '', # e.g., '-DHAVE_SOMETHING'
     INC               => '-I. -I' . Alien::TinyCC->libtcc_include_path,
     OPTIMIZE          => $OPTIMIZE,
-    # Un-comment this if you add C files to link with later:
-    OBJECT            => '$(O_FILES) ' . File::Spec->catdir(Alien::TinyCC->libtcc_library_path, 'libtcc'.$Config{lib_ext}), # link all the C files too
     META_MERGE => {
         configure_requires => {
             'Getopt::Long' => 0,
             'Cwd' => 0,
             'File::Spec' => 0,
             'File::Basename' => 0,
-            'Alien::TinyCC' => '0.03',
+            'Alien::TinyCC' => '0.06',
         },
     },
 );

--- a/lib/XS/TCC.pm
+++ b/lib/XS/TCC.pm
@@ -24,9 +24,8 @@ use File::Spec;
 use File::ShareDir;
 use Alien::TinyCC;
 
+# Needed for typemap_func.h:
 our $RuntimeIncludeDir = File::ShareDir::dist_dir('XS-TCC');
-our $TinyCCIncludeDir  = Alien::TinyCC->libtcc_include_path;
-our $TinyCCLibDir      = File::Spec->catdir( Alien::TinyCC->libtcc_library_path, 'tcc' );
 
 use XS::TCC::Typemaps;
 use XS::TCC::Parser;
@@ -143,8 +142,6 @@ SCOPE: {
   sub _get_compiler {
     #return $compiler if $compiler;
     my $compiler = XS::TCC::TCCState->new;
-    $compiler->set_lib_path($TinyCCLibDir);
-    $compiler->add_sysinclude_path($TinyCCIncludeDir);
     $compiler->add_sysinclude_path($RuntimeIncludeDir);
     if ($^O eq 'darwin') {
         $compiler->define_symbol("__XS_TCC_DARWIN__", 1);

--- a/t/10_lowlevel.t
+++ b/t/10_lowlevel.t
@@ -16,8 +16,6 @@ pass("Alive");
 
 sub make_comp {
   my $comp = XS::TCC::TCCState->new;
-  $comp->set_lib_path($XS::TCC::TinyCCLibDir);
-  $comp->add_sysinclude_path($XS::TCC::TinyCCIncludeDir);
   $comp->add_sysinclude_path($XS::TCC::RuntimeIncludeDir);
   return $comp;
 }


### PR DESCRIPTION
I've updated Alien::TinyCC to include linker and object key/value pairs for EU::MM. I've not yet uploaded the distribution, in case it needed further tweaking, but I believe it is in good shape. With these linker and object function calls, I can get XS::TCC to compiler on Windows.

I also added some material to XS::TCC itself when setting up the compilation context for Windows. Things act strangely, though, and although I could get things to compile, sorta, I couldn't get everything to run on Windows. Somebody with more Windows chops will need to look more closely at it to see what's going on.

Note that C::TinyCompiler does not suffer from the issues that XS::TCC seems to have. In particular, it does not need the extra MinGW declarations that seem to be necessary with XS::TCC. Also, C::TinyCompiler runs without segfaulting. I do not understand why the one works and the other does not.
